### PR TITLE
Performance improvements by reorg of imports.

### DIFF
--- a/vmad/__init__.py
+++ b/vmad/__init__.py
@@ -1,3 +1,3 @@
+from .core.autooperator import autooperator
 from .core.model import Builder
 from .core.operator import operator
-from .core.autooperator import autooperator

--- a/vmad/contrib/chisquare.py
+++ b/vmad/contrib/chisquare.py
@@ -1,8 +1,8 @@
 from vmad import Builder, autooperator
 from vmad.lib import mpi, linalg
 
-from pmesh.pm import ParticleMesh
 import numpy
+from pmesh.pm import ParticleMesh
 
 @autooperator
 class MPIChiSquareOperator:

--- a/vmad/core/__init__.py
+++ b/vmad/core/__init__.py
@@ -1,1 +1,11 @@
+def get_stdlib(_stdlib=[]):
+    if not _stdlib:
+        from . import stdlib
+        _stdlib.append(stdlib)
+    return _stdlib[0]
 
+def get_autodiff(_autodiff=[]):
+    if not _autodiff:
+        from . import autodiff
+        _autodiff.append(autodiff)
+    return _autodiff[0]

--- a/vmad/core/autooperator.py
+++ b/vmad/core/autooperator.py
@@ -1,14 +1,16 @@
-import inspect
-from .operator import _make_primitive, Operator, unbound, _to_ordereddict
-from .model import Builder
-from .context import Context
 from .error import ModelError
+from .model import Builder
+from .operator import BaseOperator
+from .operator import _make_primitive
+from .operator import unbound
 
-class AutoOperator(Operator):
+import inspect
+
+class AutoOperator(BaseOperator):
     """ Base class to support operators with on demand tape and prerecorded tape """
 
     def __init__(self, prototype, argnames):
-        Operator.__init__(self, prototype)
+        BaseOperator.__init__(self, prototype)
 
         impl = unbound(prototype.main)
 

--- a/vmad/core/context.py
+++ b/vmad/core/context.py
@@ -1,5 +1,6 @@
+from . import get_stdlib
 from .error import UnexpectedOutput, makeExecutionError, ModelError
-from .stdlib import terminal
+
 from collections import OrderedDict
 
 _raise_internal_errors = True
@@ -46,7 +47,7 @@ class Context(dict):
     def result_used(self, node):
         # FIXME: this doesn't remove all of the unused
         # may need to fix this in 'compile' or 'optimize'.
-        if node.primitive == terminal.apl:
+        if node.primitive == get_stdlib().terminal.apl:
             return True
 
         for argname, var in node.varout.items():
@@ -73,7 +74,7 @@ class Context(dict):
             if self.result_used(node):
                 self.execute(node, tape)
 
-            if node.primitive == terminal.apl:
+            if node.primitive == get_stdlib().terminal.apl:
                 for argname, var in node.varout.items():
                     r[var._name] = self[var._name]
 

--- a/vmad/core/node.py
+++ b/vmad/core/node.py
@@ -1,3 +1,6 @@
+from .symbol import BaseSymbol
+from .symbol import Literal
+
 class Node:
     """ A node on the computing graph.
 
@@ -10,6 +13,8 @@ class Node:
         self.primitive = primitive
         self.operator = primitive.operator
         self.prototype = primitive.operator.prototype
+        if _frameinfo is None:
+            _frameinfo = ("Unknown", "Unknown")
         self._frameinfo = _frameinfo
 
         # add a few aliases for accessing primitive attributes
@@ -45,7 +50,6 @@ class Node:
 
             Returns: dict, result for each varout.
         """
-        from .symbol import BaseSymbol
         for key, value in kwargs.items():
             assert not isinstance(value, BaseSymbol)
 
@@ -88,7 +92,6 @@ class Node:
         d = {}
         d.update(r)
         d.update(kwargs)
-        from .symbol import BaseSymbol
         for key, value in d.items():
             assert not isinstance(value, BaseSymbol)
         return self.primitive.record_impl(self, **d)
@@ -106,5 +109,4 @@ class Node:
         if func == 'apl': return node.operator.apl
 
     def is_literal(self, argname):
-        from vmad.core.symbol import Literal
         return isinstance(self.varin[argname].symbol, Literal)

--- a/vmad/core/primitive.py
+++ b/vmad/core/primitive.py
@@ -1,11 +1,13 @@
-import inspect
-from collections import OrderedDict
-
 from .error import UnpackError, OverwritePrecaution, MissingArgument, BrokenPrimitive, BadArgument
-from .node import Node
-
-from .symbol import Symbol, assymbol, BaseSymbol, Literal, List
 from .model import Model
+from .node import Node
+from .symbol import assymbol
+from .symbol import List
+from .symbol import Literal
+from .symbol import Symbol
+
+from collections import OrderedDict
+import inspect
 
 def get_default_args(func):
     signature = inspect.signature(func)
@@ -66,15 +68,18 @@ class Primitive:
         """
         if kwout is None: # generate output arguments.
             kwout = {}
-        # remember the frame info
-        previous_frame = inspect.currentframe()
 
-        while stacklevel < 0:
-            previous_frame = previous_frame.f_back
-            stacklevel = stacklevel + 1
+        if stacklevel is not None:
+            # remember the frame info
+            previous_frame = inspect.currentframe()
 
-        _frameinfo = inspect.getframeinfo(previous_frame)
+            while stacklevel < 0:
+                previous_frame = previous_frame.f_back
+                stacklevel = stacklevel + 1
 
+            _frameinfo = inspect.getframeinfo(previous_frame)
+        else:
+            _frameinfo = None
         node = Node(self, _frameinfo)
 
         # FIXME: this is tricky.
@@ -189,7 +194,6 @@ class Primitive:
 
 
 def _check_var_references(var):
-    from .symbol import List
     if isinstance(var, List):
         for v in var:
             _check_var_references(v)
@@ -206,7 +210,7 @@ def _join_models(models, m1):
 def _infer_models(var):
 
     if isinstance(var, Symbol):
-        model = var._model
+        model = Model.get_model(var)
         if model is not None:
             return [model]
         else:

--- a/vmad/core/stdlib/operators.py
+++ b/vmad/core/stdlib/operators.py
@@ -1,5 +1,7 @@
 from vmad.core.operator import operator
 
+from builtins import abs as abs_
+
 class unary:
     ain = 'x'
     aout = 'y'
@@ -34,9 +36,7 @@ class pos(unary):
 @operator
 class abs(unary):
     def apl(node, x):
-        # function name was replaced
-        from builtins import abs
-        return dict(y = abs(x))
+        return dict(y = abs_(x))
 
     def vjp(node, _y, x):
         return dict(_x = _y * (x > 0) + -_y * (x < 0))
@@ -93,7 +93,6 @@ class div(binary):
         return dict(y = x1 * x2inv, x2inv=x2inv)
 
     def rcd(node, x1, x2inv, y, x2):
-        from vmad.core.symbol import Literal
         # the other value is not needed, 0 should work.
         if node.is_literal('x1'):
             x1fac = 0

--- a/vmad/core/stdlib/utils.py
+++ b/vmad/core/stdlib/utils.py
@@ -6,6 +6,8 @@
 
 from vmad.core.operator import operator, ZeroGradient
 
+from builtins import eval as eval_
+
 @operator
 class eval:
     ain  = 'x'
@@ -24,8 +26,7 @@ class eval:
         if hasattr(function, '__call__'):
             return dict(y=function(x))
         else:
-            from builtins import eval
-            return dict(y=eval(function, dict(x=x)))
+            return dict(y=eval_(function, dict(x=x)))
 
     def vjp(node): return ZeroGradient
     def jvp(node): return ZeroGradient

--- a/vmad/core/symbol.py
+++ b/vmad/core/symbol.py
@@ -1,7 +1,7 @@
+from . import get_stdlib
 from .error import ResolveError
-import weakref
 
-from . import stdlib
+import weakref
 
 class BaseSymbol(object):
     """ A symbol for building models.
@@ -41,7 +41,7 @@ class BaseSymbol(object):
 
     def eval(self, function):
         """ Evaluates an expression or a function on the symbol. see vmad.core.stdlib.eval. """
-        return stdlib.eval(self, function)
+        return get_stdlib().eval(self, function)
 
     # workaround numpy's operator overrides, which
     # is higher priority than rxxx methodds (radd) defined here.
@@ -49,30 +49,30 @@ class BaseSymbol(object):
     # __array_ufunc__ to dispatch this in the future.
     __array_priority__ = 15.0
 
-    def __add__(self, other): return stdlib.add(self, other, __stacklevel__=-3)
-    def __radd__(self, other): return stdlib.add(other, self, __stacklevel__=-3)
-    def __sub__(self, other): return stdlib.sub(self, other, __stacklevel__=-3)
-    def __rsub__(self, other): return stdlib.sub(other, self, __stacklevel__=-3)
-    def __mul__(self, other): return stdlib.mul(self, other, __stacklevel__=-3)
-    def __rmul__(self, other): return stdlib.mul(other, self, __stacklevel__=-3)
-    def __mod__(self, other): return stdlib.mod(self, other, __stacklevel__=-3)
-    def __rmod__(self, other): return stdlib.mod(other, self, __stacklevel__=-3)
-    def __truediv__(self, other): return stdlib.div(self, other, __stacklevel__=-3)
-    def __rtruediv__(self, other): return stdlib.div(other, self, __stacklevel__=-3)
+    def __add__(self, other): return get_stdlib().add(self, other, __stacklevel__=-3)
+    def __radd__(self, other): return get_stdlib().add(other, self, __stacklevel__=-3)
+    def __sub__(self, other): return get_stdlib().sub(self, other, __stacklevel__=-3)
+    def __rsub__(self, other): return get_stdlib().sub(other, self, __stacklevel__=-3)
+    def __mul__(self, other): return get_stdlib().mul(self, other, __stacklevel__=-3)
+    def __rmul__(self, other): return get_stdlib().mul(other, self, __stacklevel__=-3)
+    def __mod__(self, other): return get_stdlib().mod(self, other, __stacklevel__=-3)
+    def __rmod__(self, other): return get_stdlib().mod(other, self, __stacklevel__=-3)
+    def __truediv__(self, other): return get_stdlib().div(self, other, __stacklevel__=-3)
+    def __rtruediv__(self, other): return get_stdlib().div(other, self, __stacklevel__=-3)
     def __pow__(self, other, modulo=None):
         if modulo is not None:
             raise ValueError("pow with modulo is not supported")
-        return stdlib.pow(self, other, __stacklevel__=-3)
+        return get_stdlib().pow(self, other, __stacklevel__=-3)
     def __rpow__(self, other):
         raise
-        return stdlib.pow(other, self, __stacklevel__=-3)
+        return get_stdlib().pow(other, self, __stacklevel__=-3)
 
     def __floordiv__(self, other): raise TypeError("floor div is not supported in autodiff")
     def __rfloordiv__(self, other): raise TypeError("floor div is not supported in autodiff")
 
-    def __neg__(self): return stdlib.neg(self, __stacklevel__=-3)
-    def __pos__(self): return stdlib.pos(self, __stacklevel__=-3)
-    def __abs__(self): return stdlib.abs(self, __stacklevel__=-3)
+    def __neg__(self): return get_stdlib().neg(self, __stacklevel__=-3)
+    def __pos__(self): return get_stdlib().pos(self, __stacklevel__=-3)
+    def __abs__(self): return get_stdlib().abs(self, __stacklevel__=-3)
 
 class Ref(object):
     """
@@ -91,7 +91,6 @@ class Ref(object):
         """ Returns a list of symbol names that are referenced by
             this object, recursively
         """
-        from .symbol import Symbol
         l = set([])
         symbol = self.symbol
         # recusrively get the name of the parents
@@ -121,25 +120,6 @@ class Symbol(BaseSymbol):
         if model is not None:
             # anchor it now
             model.anchor(self)
-
-    @property
-    def _model(self):
-        from .model import ModelInTransient
-        if self._model_ref is None:
-            return None
-        if isinstance(self._model_ref, ModelInTransient):
-            return self._model_ref
-        else:
-            return self._model_ref()
-
-    @property
-    def _anchored(self):
-        return self._model_ref is not None
-
-    @property
-    def _transient(self):
-        from .model import ModelInTransient
-        return isinstance(self._model_ref, ModelInTransient)
 
     def __repr__(self):
         return self._name

--- a/vmad/core/tape.py
+++ b/vmad/core/tape.py
@@ -1,4 +1,4 @@
-from . import autodiff
+from . import get_autodiff
 
 class Record(object):
     """ A record on the tape. 
@@ -43,11 +43,11 @@ class Tape(list):
 
     def get_vjp(self):
         assert self._completed
-        return autodiff.vjpmodel(self)
+        return get_autodiff().vjpmodel(self)
 
     def get_jvp(self):
         assert self._completed
-        return autodiff.jvpmodel(self)
+        return get_autodiff().jvpmodel(self)
 
     def compute_jvjp(self, vout, aout, init):
         jvp = self.get_jvp()

--- a/vmad/core/tests/test_autooperator.py
+++ b/vmad/core/tests/test_autooperator.py
@@ -1,9 +1,8 @@
-from __future__ import print_function
-
-from vmad.core.model import Builder
-from vmad.core.error import BadArgument
 from vmad.core.autooperator import autooperator
+from vmad.core.error import BadArgument
+from vmad.core.model import Builder
 from vmad.lib.linalg import add
+
 import pytest
 
 @autooperator

--- a/vmad/core/tests/test_error.py
+++ b/vmad/core/tests/test_error.py
@@ -1,5 +1,6 @@
 from vmad.core.model import Builder
 from vmad.core.stdlib import add
+
 import pytest
 
 def test_error_infer():

--- a/vmad/core/tests/test_model.py
+++ b/vmad/core/tests/test_model.py
@@ -1,8 +1,9 @@
-from __future__ import print_function
-from pprint import pprint
-from vmad.lib.linalg import mul
-from vmad.lib.linalg import add
 from vmad.core.model import Builder
+from vmad.core.model import Model
+from vmad.lib.linalg import add
+from vmad.lib.linalg import mul
+
+from pprint import pprint
 import pytest
 
 def test_model_build():
@@ -13,14 +14,14 @@ def test_model_build():
     def upsample2(Sl, Ql):  #pm has the same resolution as Ql
 
         layout = add(Ql, 1)
-        print(id(layout._model), len(layout._model))
+        print(id(Model.get_model(layout)), len(Model.get_model(layout)))
         Ql1 = add(Ql, layout)
-        print(id(layout._model), id(Ql1._model), len(layout._model))
+        print(id(Model.get_model(layout)), id(Model.get_model(Ql1)), len(Model.get_model(layout)))
         Sl1 = add(Sl, layout)
-        print(id(layout._model), id(Ql1._model), len(layout._model))
+        print(id(Model.get_model(layout)), id(Model.get_model(Ql1)), len(Model.get_model(layout)))
 
         dis_d = add(Ql1, Sl1)
-        print(id(layout._model), id(Ql1._model), len(layout._model))
+        print(id(Model.get_model(layout)), id(Model.get_model(Ql1)), len(Model.get_model(layout)))
 
         return dis_d
 

--- a/vmad/core/tests/test_operator.py
+++ b/vmad/core/tests/test_operator.py
@@ -1,8 +1,7 @@
-from __future__ import print_function
+from vmad.core.model import Builder
+from vmad.core.operator import operator, ZeroGradient
 
 from pprint import pprint
-from vmad.core.operator import operator, ZeroGradient
-from vmad.core.model import Builder
 import pytest
 
 @operator

--- a/vmad/core/tests/test_stdlib.py
+++ b/vmad/core/tests/test_stdlib.py
@@ -1,9 +1,8 @@
-from __future__ import print_function
+from vmad.core.model import Builder
+from vmad.lib import linalg
 
 from pprint import pprint
-from vmad.core.model import Builder
 import pytest
-from vmad.lib import linalg
 
 def test_operator_watchpoint():
     from vmad.core.stdlib import watchpoint

--- a/vmad/core/tests/test_symbol.py
+++ b/vmad/core/tests/test_symbol.py
@@ -1,6 +1,6 @@
-from vmad.core.symbol import Symbol
-from vmad.core.operator import operator
 from vmad import Builder
+from vmad.core.operator import operator
+from vmad.core.symbol import Symbol
 
 def test_symbol_eval():
     with Builder() as m:

--- a/vmad/lib/binary.py
+++ b/vmad/lib/binary.py
@@ -1,6 +1,5 @@
 from vmad import operator
-from vmad.core.symbol import Literal, ZeroLiteral
-from vmad.core.symbol import Symbol
+
 import numpy
 
 class binary_ufunc:

--- a/vmad/lib/coarray.py
+++ b/vmad/lib/coarray.py
@@ -1,4 +1,5 @@
 from vmad import operator
+
 import numpy
 
 @operator

--- a/vmad/lib/fastpm.py
+++ b/vmad/lib/fastpm.py
@@ -1,6 +1,9 @@
 from vmad import operator, autooperator
-from pmesh.pm import ParticleMesh
+from vmad.core.stdlib import watchpoint
 from vmad.lib import linalg
+
+from fastpm.background import MatterDominated
+from pmesh.pm import ParticleMesh
 import numpy
 
 @operator
@@ -405,7 +408,6 @@ def lpt(rhok, q, pm):
 
 @autooperator('dx->f,potk')
 def gravity(dx, q, pm):
-    from vmad.core.stdlib import watchpoint
     x = q + dx
     #def w(q): print('q', q)
     #watchpoint(x, w)
@@ -494,7 +496,6 @@ def firststep(rhok, q, a, pt, pm):
 
 @autooperator('rhok->dx,p,f')
 def nbody(rhok, q, stages, cosmology, pm):
-    from fastpm.background import MatterDominated
 
     stages = numpy.array(stages)
     mid = (stages[1:] * stages[:-1]) ** 0.5
@@ -527,8 +528,6 @@ class cdot:
 
 class FastPMSimulation:
     def __init__(self, stages, cosmology, pm, B=1, q=None):
-        from fastpm.background import MatterDominated
-
         if q is None:
             q = pm.generate_uniform_particle_grid()
 

--- a/vmad/lib/linalg.py
+++ b/vmad/lib/linalg.py
@@ -1,7 +1,4 @@
 from vmad import operator
-
-import numpy
-
 # a few commonly used operators are expected to be
 # compatible with the python ones.
 from vmad.core.stdlib import mul, add, abs, pow, div, mod
@@ -9,6 +6,7 @@ from vmad.core.stdlib import mul, add, abs, pow, div, mod
 # import all functions defined in unary module
 from vmad.lib.unary import *
 
+import numpy
 from numpy.core.einsumfunc import _parse_einsum_input
 
 @operator

--- a/vmad/lib/mpi.py
+++ b/vmad/lib/mpi.py
@@ -10,7 +10,9 @@ collective : an operation that is performed by all ranks.
 
 """
 
-from vmad import operator, autooperator
+from vmad import autooperator
+from vmad import operator
+
 import numpy
 
 @operator

--- a/vmad/lib/tests/test_binary.py
+++ b/vmad/lib/tests/test_binary.py
@@ -1,12 +1,10 @@
-from __future__ import print_function
-from pprint import pprint
-from vmad.lib import linalg
-import numpy
-
-from vmad.lib import binary
-
 from vmad import Builder
+from vmad.lib import binary
+from vmad.lib import linalg
 from vmad.testing import BaseVectorTest
+
+import numpy
+from pprint import pprint
 
 class BinaryUfuncVectorTest(BaseVectorTest):
     ufunc = None

--- a/vmad/lib/tests/test_fastpm.py
+++ b/vmad/lib/tests/test_fastpm.py
@@ -1,13 +1,13 @@
-from __future__ import print_function
-from pprint import pprint
-from vmad.lib import fastpm, linalg
-import numpy
 from vmad import autooperator
-
+from vmad.lib import fastpm, linalg
 from vmad.testing import BaseScalarTest
+
 from mpi4py import MPI
+import numpy
 from numpy.testing import assert_allclose
+
 from pmesh.pm import RealField, ComplexField
+from pprint import pprint
 
 def create_bases(x):
     bases = numpy.eye(x.size).reshape([-1] + list(x.shape))

--- a/vmad/lib/tests/test_linalg.py
+++ b/vmad/lib/tests/test_linalg.py
@@ -1,11 +1,10 @@
-from __future__ import print_function
-from pprint import pprint
-from vmad.lib import linalg
-from vmad.core import stdlib
-import numpy
-
 from vmad import Builder
+from vmad.core import stdlib
+from vmad.lib import linalg
 from vmad.testing import BaseVectorTest
+
+import numpy
+from pprint import pprint
 
 class Test_pack_complex(BaseVectorTest):
     x = numpy.arange(10) # will pack to complex of x + x * 1j

--- a/vmad/lib/tests/test_mpi.py
+++ b/vmad/lib/tests/test_mpi.py
@@ -1,11 +1,9 @@
-from __future__ import print_function
-from pprint import pprint
 from vmad.lib import linalg, mpi
-
-import numpy
-
 from vmad.testing import BaseScalarTest
+
 from mpi4py import MPI
+import numpy
+from pprint import pprint
 
 class Test_allreduce(BaseScalarTest):
     to_scalar = staticmethod(linalg.to_scalar)

--- a/vmad/lib/tests/test_unary.py
+++ b/vmad/lib/tests/test_unary.py
@@ -1,12 +1,10 @@
-from __future__ import print_function
-from pprint import pprint
-from vmad.lib import linalg
-import numpy
-
-from vmad.lib import unary
-
 from vmad import Builder
+from vmad.lib import linalg
+from vmad.lib import unary
 from vmad.testing import BaseVectorTest
+
+import numpy
+from pprint import pprint
 
 class UnaryUfuncVectorTest(BaseVectorTest):
     ufunc = None

--- a/vmad/lib/unary.py
+++ b/vmad/lib/unary.py
@@ -1,6 +1,8 @@
 from vmad import operator
-from vmad.core.symbol import Literal, ZeroLiteral
+from vmad.core.symbol import Literal
 from vmad.core.symbol import Symbol
+from vmad.core.symbol import ZeroLiteral
+
 import numpy
 
 class unary_ufunc:

--- a/vmad/testing.py
+++ b/vmad/testing.py
@@ -1,7 +1,8 @@
 from vmad import Builder
-from numpy.testing import assert_array_equal, assert_allclose
 
 import numpy
+from numpy.testing import assert_array_equal, assert_allclose
+
 
 class BaseScalarTest:
     """ Basic correctness of gradient against numerical with to_scalar """

--- a/vmad/tests/test_vmad3.py
+++ b/vmad/tests/test_vmad3.py
@@ -1,10 +1,8 @@
-from __future__ import print_function
-
-from vmad import Builder
 from vmad import autooperator
+from vmad import Builder
 from vmad import operator
-
 from vmad.lib.linalg import add
+
 from pprint import pprint
 
 def test_vmad3_functional():


### PR DESCRIPTION
It turns out that the workaround for circular imports is taking
quite a bit of time as it is called in hot functions.

The dependency on stdlib and autodiff are now routed through
vmad.core.get_stdlib() and vmad.core.get_autodiff()

I also reordered the import lines at header of each file.

Another change was to avoid recording the stack (calling into expensive inspect) during autodiff.
